### PR TITLE
Provide the Accept header in all requests

### DIFF
--- a/certbot_glesys.py
+++ b/certbot_glesys.py
@@ -47,6 +47,7 @@ class GlesysDomainApiClient(object):
     def __init__(self, username, password):
         self._client = Session()
         self._client.auth = HTTPBasicAuth(username, password)
+        self._client.headers.update({"Accept": "application/xml"})
 
     def _request(self, type, action, data=None):
         url = u"{}/{}/{}/".format(self.base_url, type, action)


### PR DESCRIPTION
A recent update of the content negotiation in the GleSYS API introduced a non-backward compatible change where the response format could not be determined. This occurs when the `Accept` header as well as the `format` parameter is missing from the request and `Content-Type` is set to `application/x-www-form-urlencoded`.

To ensure that XML is returned by the GleSYS API the `Accept` header should be provided with the value of `application/xml`.